### PR TITLE
ECS (NodeJS)

### DIFF
--- a/app/deploy/task-definition.json
+++ b/app/deploy/task-definition.json
@@ -1,0 +1,71 @@
+{
+  "family": "ecs-nodejs",
+  "executionRoleArn": "arn:aws:iam::765774143504:role/sandbox-ecs-execution",
+  "taskRoleArn": "arn:aws:iam::765774143504:role/sandbox-ecs-task",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "256",
+  "memory": "512",
+  "containerDefinitions": [
+    {
+      "name": "ecs-nodejs",
+      "image": "765774143504.dkr.ecr.eu-west-1.amazonaws.com/sandbox-ecs-nodejs:latest",
+      "cpu": 0,
+      "essential": true,
+      "portMappings": [
+        {
+          "hostPort": 3000,
+          "protocol": "tcp",
+          "containerPort": 3000
+        }
+      ],
+      "environment": [],
+      "secrets": [],
+      "healthCheck": {
+        "retries": 2,
+        "command": [
+          "CMD-SHELL",
+          "curl -f http://localhost:3000/ || exit 1"
+        ],
+        "timeout": 2,
+        "interval": 10,
+        "startPeriod": 10
+      },
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/ecs-nodejs",
+          "awslogs-region": "eu-west-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ],
+  "runtimePlatform": {
+    "operatingSystemFamily": "LINUX"
+  },
+  "tags": [
+    {
+      "key": "Name",
+      "value": "ecs-nodejs"
+    },
+    {
+      "key": "Description",
+      "value": "ECS example NodeJS task definition"
+    },
+    {
+      "key": "App",
+      "value": "terraform-ecs"
+    },
+    {
+      "key": "Repo",
+      "value": "https://github.com/tobias-g/terraform-ecs"
+    },
+    {
+      "key": "Environment",
+      "value": "sandbox"
+    }
+  ]
+}

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,5 +1,5 @@
 resource "aws_ecr_repository" "main" {
-  name                 = local.prefix
+  name                 = "${local.prefix}-nodejs"
   image_tag_mutability = "MUTABLE"
 
   image_scanning_configuration {

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -15,3 +15,8 @@ resource "aws_ecr_repository" "main" {
     Description = "Example ECS elastic container registry for NodeJS Docker image"
   }
 }
+
+resource "aws_iam_role_policy_attachment" "task" {
+  role       = aws_iam_role.task.name
+  policy_arn = aws_iam_policy.task.arn
+}

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,0 +1,104 @@
+# Most of the ECS stuff we'll setup in the ecs module to encapsulate it but
+# since we will want to deploy to multiple regions some resources that are
+# global are defined outside the module. An example being the IAM roles (we
+# don't/can't deploy a copy of these per region as we would get name clashes).
+
+data "aws_iam_policy_document" "execution" {
+  statement {
+    sid = "ECRAndLogs"
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailibility",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams",
+    ]
+
+    resources = ["*"] # todo we can tighten this to certain log groups and ecrs
+  }
+}
+
+resource "aws_iam_policy" "execution" {
+  name        = "${local.prefix}-execution"
+  description = "ECS execution role for ${var.environment}"
+  policy      = data.aws_iam_policy_document.execution.json
+
+  tags = {
+    Name        = "${local.prefix}-execution"
+    Description = "ECS execution policy for ${var.environment}"
+  }
+}
+
+data "aws_iam_policy_document" "execution_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "execution" {
+  name               = "${local.prefix}-execution"
+  assume_role_policy = data.aws_iam_policy_document.execution_assume.json
+
+  tags = {
+    Name        = "${local.prefix}-execution"
+    Description = "ECS execution role for ${var.environment}"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "execution" {
+  role       = aws_iam_role.execution.name
+  policy_arn = aws_iam_policy.execution.arn
+}
+
+data "aws_iam_policy_document" "task" {
+  statement {
+    sid = "LogAccess"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams",
+    ]
+    resources = ["*"] # todo we can tighten this to certain log groups
+  }
+}
+
+resource "aws_iam_policy" "task" {
+  name        = "${local.prefix}-task"
+  description = "ECS task policy for ${var.environment}"
+  policy      = data.aws_iam_policy_document.task.json
+
+  tags = {
+    Name        = "${local.prefix}-task"
+    Description = "ECS task policy for ${var.environment}"
+  }
+}
+
+data "aws_iam_policy_document" "task_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task" {
+  name               = "${local.prefix}-task"
+  assume_role_policy = data.aws_iam_policy_document.task_assume.json
+
+  tags = {
+    Name        = "${local.prefix}-task"
+    Description = "ECS task role for ${var.environment}"
+  }
+}

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -102,3 +102,11 @@ resource "aws_iam_role" "task" {
     Description = "ECS task role for ${var.environment}"
   }
 }
+
+module "ecs_nodejs" {
+  source          = "./modules/ecs"
+  environment     = var.environment
+  vpc_id          = module.network.vpc_id
+  private_subnets = module.network.private_subnets
+  public_subnets  = module.network.public_subnets
+}

--- a/terraform/modules/ecs/README.md
+++ b/terraform/modules/ecs/README.md
@@ -1,0 +1,3 @@
+# ECS
+
+Creates a ECS cluster to run our Docker apps in.

--- a/terraform/modules/ecs/acm.tf
+++ b/terraform/modules/ecs/acm.tf
@@ -1,0 +1,13 @@
+resource "aws_acm_certificate" "main" {
+  domain_name       = "ecs-nodejs.${local.domain}"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name        = "ecs-nodejs.${local.domain}"
+    Description = "ECS example NodeJS application domain"
+  }
+}

--- a/terraform/modules/ecs/cluster.tf
+++ b/terraform/modules/ecs/cluster.tf
@@ -1,0 +1,15 @@
+resource "aws_ecs_cluster" "main" {
+  name = local.prefix
+
+  # Disable these as I don't want to pay for extra custom metrics but in a real
+  # production environment this would likely be enabled.
+  setting {
+    name  = "containerInsights"
+    value = "disabled"
+  }
+
+  tags = {
+    Name        = local.prefix
+    Description = "ECS example cluster"
+  }
+}

--- a/terraform/modules/ecs/data.tf
+++ b/terraform/modules/ecs/data.tf
@@ -1,0 +1,7 @@
+# We'll grab the latest task definition instead of creating it in Terraform.
+# This is because we'll create & update the task definition in our "app" folder
+# and deploy it from there too. This is essentially the line between what is an
+# app deploy and what is an infrastructure deploy.
+data "aws_ecs_task_definition" "nodejs" {
+  task_definition = "ecs-nodejs"
+}

--- a/terraform/modules/ecs/load-balancer.tf
+++ b/terraform/modules/ecs/load-balancer.tf
@@ -1,0 +1,58 @@
+resource "aws_lb" "main" {
+  name                       = "${local.prefix}-nodejs"
+  internal                   = false
+  load_balancer_type         = "application"
+  security_groups            = [aws_security_group.load_balancer.id]
+  subnets                    = var.public_subnets
+  drop_invalid_header_fields = true
+  enable_deletion_protection = true
+
+  tags = {
+    Name        = "${local.prefix}-nodejs"
+    Description = "ECS example NodeJS service load balancer"
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = 443
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  tags = {
+    Name        = "${local.prefix}-nodejs"
+    Description = "ECS example NodeJS service HTTP listener redirects to HTTPS"
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = aws_acm_certificate.main.arn
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Teapot"
+      status_code  = "417"
+    }
+  }
+
+  tags = {
+    Name        = "${local.prefix}-nodejs"
+    Description = "ECS example NodeJS service HTTPS listener forwards to ECS once service is deployed"
+  }
+}

--- a/terraform/modules/ecs/locals.tf
+++ b/terraform/modules/ecs/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  prefix = "${var.environment}-ecs"
+  domain = "northbayworkshop.co.uk"
+}

--- a/terraform/modules/ecs/logs.tf
+++ b/terraform/modules/ecs/logs.tf
@@ -1,0 +1,9 @@
+resource "aws_cloudwatch_log_group" "main" {
+  name              = "/ecs/ecs-nodejs"
+  retention_in_days = 7
+
+  tags = {
+    Name        = "/ecs/ecs-nodejs"
+    Description = "ECS example NodeJS application logs"
+  }
+}

--- a/terraform/modules/ecs/security-groups.tf
+++ b/terraform/modules/ecs/security-groups.tf
@@ -1,0 +1,71 @@
+resource "aws_security_group" "ecs" {
+  name        = "${local.prefix}-nodejs"
+  description = "Allow access from load balancer to ECS for ${local.prefix}-nodejs"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name        = "${local.prefix}-nodejs"
+    Description = "Allow access from load balancer to ECS for ${local.prefix}-nodejs"
+  }
+}
+
+resource "aws_security_group_rule" "ecs_egress" {
+  description       = "Allow egress anywhere for ${local.prefix}-nodejs"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  security_group_id = aws_security_group.ecs.id
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "ecs_ingress" {
+  description              = "Allow loadbalancer ingress to ECS ${local.prefix}-nodejs"
+  source_security_group_id = aws_security_group.load_balancer.id
+  from_port                = 3000
+  to_port                  = 3000
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.ecs.id
+  type                     = "ingress"
+}
+
+resource "aws_security_group" "load_balancer" {
+  name        = "${local.prefix}-nodejs-lb"
+  description = "Allow access to load balancer for ${local.prefix}-nodejs"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name        = "${local.prefix}-nodejs-lb"
+    Description = "Allow access to load balancer for ${local.prefix}-nodejs"
+  }
+}
+
+resource "aws_security_group_rule" "load_balancer_egress" {
+  description              = "Allow egress for ${local.prefix}-nodejs"
+  source_security_group_id = aws_security_group.ecs.id
+  from_port                = 3000
+  to_port                  = 3000
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.load_balancer.id
+  type                     = "egress"
+}
+
+resource "aws_security_group_rule" "load_balancer_https_ingress" {
+  description       = "Allow loadbalancer HTTPS ingress"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 443
+  to_port           = 443
+  protocol          = "TCP"
+  security_group_id = aws_security_group.load_balancer.id
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "load_balancer_http_ingress" {
+  description       = "Allow loadbalancer HTTPS ingress"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 80
+  to_port           = 80
+  protocol          = "TCP"
+  security_group_id = aws_security_group.load_balancer.id
+  type              = "ingress"
+}

--- a/terraform/modules/ecs/service.tf
+++ b/terraform/modules/ecs/service.tf
@@ -1,0 +1,26 @@
+resource "aws_ecs_service" "nodejs" {
+  name                              = "ecs-nodejs"
+  cluster                           = aws_ecs_cluster.main.arn
+  task_definition                   = "ecs-nodejs:${data.aws_ecs_task_definition.nodejs.revision}"
+  desired_count                     = 1
+  health_check_grace_period_seconds = 300
+  propagate_tags                    = "TASK_DEFINITION"
+  launch_type                       = "FARGATE"
+
+  network_configuration {
+    subnets          = var.private_subnets
+    security_groups  = [aws_security_group.ecs.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    container_name   = "ecs-nodejs"
+    target_group_arn = aws_lb_target_group.green.arn
+    container_port   = 3000
+  }
+
+  tags = {
+    Name        = "ecs-nodejs"
+    Description = "ECS service for our NodeJS app"
+  }
+}

--- a/terraform/modules/ecs/target-groups.tf
+++ b/terraform/modules/ecs/target-groups.tf
@@ -1,0 +1,61 @@
+resource "aws_lb_target_group" "blue" {
+  name                 = "${local.prefix}-nodejs-blue"
+  port                 = 80
+  protocol             = "HTTP"
+  target_type          = "ip"
+  vpc_id               = var.vpc_id
+  deregistration_delay = 0
+
+  health_check {
+    healthy_threshold   = 5
+    path                = "/"
+    unhealthy_threshold = 2
+  }
+
+  tags = {
+    Name        = "${local.prefix}-nodejs-blue"
+    Description = "ECS example NodeJS app blue target group"
+  }
+}
+
+resource "aws_lb_target_group" "green" {
+  name                 = "${local.prefix}-nodejs-green"
+  port                 = 80
+  protocol             = "HTTP"
+  target_type          = "ip"
+  vpc_id               = var.vpc_id
+  deregistration_delay = 0
+
+  health_check {
+    healthy_threshold   = 5
+    path                = "/"
+    unhealthy_threshold = 2
+  }
+
+  tags = {
+    Name        = "${local.prefix}-nodejs-green"
+    Description = "ECS example NodeJS app green target group"
+  }
+}
+
+resource "aws_lb_listener_rule" "main" {
+  listener_arn = aws_lb_listener.https.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.green.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["*"]
+    }
+  }
+
+  tags = {
+    Name        = "${local.prefix}-nodejs main"
+    Description = "ECS example NodeJS loadbalancer/target group HTTPS listener"
+  }
+}
+

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -1,0 +1,23 @@
+variable "environment" {
+  type        = string
+  description = "Environment we are deploying to either sandbox, staging or prod"
+  validation {
+    condition     = contains(["sandbox", "staging", "prod"], var.environment)
+    error_message = "Environment must be either \"sandbox\", \"staging\" or \"prod\"."
+  }
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC we're deploying our infrastructure into"
+}
+
+variable "private_subnets" {
+  type        = list(string)
+  description = "List of private subnets to deploy our containers to"
+}
+
+variable "public_subnets" {
+  type        = list(string)
+  description = "List of public subnets to deploy our loadbalancer to"
+}

--- a/terraform/modules/network/outputs.tf
+++ b/terraform/modules/network/outputs.tf
@@ -1,0 +1,17 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "private_subnets" {
+  value = [
+    aws_subnet.private_a.id,
+    aws_subnet.private_b.id,
+  ]
+}
+
+output "public_subnets" {
+  value = [
+    aws_subnet.public_a.id,
+    aws_subnet.public_b.id,
+  ]
+}


### PR DESCRIPTION
Adds a single NodeJS application to ECS.

I've setup ACM for HTTPS and used a domain I already own for this manually verifying it. Thats because it's in a different AWS account and I didn't want to buy a new domain for this example. Otherwise we could have instead created the ACM verification in Terraform too.

Adds loadbalancer that points to a green target group which then points to the ECS service/task. There's a blue unused target group I'll use later for blue/green deploys via CodeDeploy.

ECS task runs in private subnets and loadbalancer in public so accesible via internet. Enhancement would be to have this go through CloudFront add WAF, caching etc. Will do that if I have time to get around to it.